### PR TITLE
Fix rift detection

### DIFF
--- a/src/main/java/de/kuschel_swein/minecraft/smixer/mixins/sba/utils/UtilsMixin.java
+++ b/src/main/java/de/kuschel_swein/minecraft/smixer/mixins/sba/utils/UtilsMixin.java
@@ -18,6 +18,9 @@ import java.util.Set;
 @Mixin(Utils.class)
 public class UtilsMixin implements MixedUtils {
 
+    @Unique
+    private static final int RIFT_SCOREBOARD_LINE = 2;
+
     @Final
     @Shadow(remap = false)
     private static Set<String> SKYBLOCK_IN_ALL_LANGUAGES;
@@ -52,7 +55,7 @@ public class UtilsMixin implements MixedUtils {
         List<String> strippedScoreboardLines = ScoreboardManager.getStrippedScoreboardLines();
 
         if (strippedScoreboardLines != null) {
-            String strippedLine = strippedScoreboardLines.get(2);
+            String strippedLine = strippedScoreboardLines.get(RIFT_SCOREBOARD_LINE);
 
             // store if we are in the rift
             this.isInRift = (strippedLine != null && strippedLine.equals("Rift Dimension"));

--- a/src/main/java/de/kuschel_swein/minecraft/smixer/mixins/sba/utils/UtilsMixin.java
+++ b/src/main/java/de/kuschel_swein/minecraft/smixer/mixins/sba/utils/UtilsMixin.java
@@ -54,7 +54,7 @@ public class UtilsMixin implements MixedUtils {
         // BUT: there are like a million of them, so this is just the cleaner solution
         List<String> strippedScoreboardLines = ScoreboardManager.getStrippedScoreboardLines();
 
-        if (strippedScoreboardLines != null) {
+        if (strippedScoreboardLines != null && (strippedScoreboardLines.size() > RIFT_SCOREBOARD_LINE)) {
             String strippedLine = strippedScoreboardLines.get(RIFT_SCOREBOARD_LINE);
 
             // store if we are in the rift


### PR DESCRIPTION
Currently there is the possibility of an `OutOfBounds` exception to be thrown, this is prevented by this PR by checking the size of the scoreboard lines first.